### PR TITLE
Add curriculum development workflow definition and update imports

### DIFF
--- a/server/src/v2/workflow/data/lasta-workflow-definition.json
+++ b/server/src/v2/workflow/data/lasta-workflow-definition.json
@@ -1,0 +1,1538 @@
+{
+  "id": "lasta-programme-development",
+  "version": 1,
+  "name": "Lasta Programme Development",
+  "description": "Guides a university programme from initial needs analysis through curriculum development, stakeholder consultation, institutional approval, and final NQF registration.",
+  "roles": [
+    {
+      "id": "initiator",
+      "name": "Programme Initiator"
+    },
+    {
+      "id": "pdqa",
+      "name": "PDQA"
+    },
+    {
+      "id": "cdc",
+      "name": "Curriculum Development Committee"
+    },
+    {
+      "id": "pac",
+      "name": "Programme Advisory Committee"
+    },
+    {
+      "id": "bos",
+      "name": "Board of Studies"
+    },
+    {
+      "id": "apc",
+      "name": "Academic Planning Committee"
+    },
+    {
+      "id": "senate",
+      "name": "Senate"
+    },
+    {
+      "id": "adstlt",
+      "name": "ADSTLT / TLU"
+    },
+    {
+      "id": "ceu",
+      "name": "Cooperative Education Unit"
+    },
+    {
+      "id": "nqa",
+      "name": "NQA Liaison"
+    }
+  ],
+  "stages": [
+    {
+      "id": "need-analysis",
+      "name": "Need Analysis",
+      "order": 1,
+      "description": "Establish whether there is a justified need for the proposed programme through stakeholder consultation, PDQA review, BOS, APC and Senate consideration."
+    },
+    {
+      "id": "programme-development",
+      "name": "Programme Development",
+      "order": 2,
+      "description": "Appoint the Curriculum Development Coordinator and Programme Advisory Committee, then develop the draft programme for PDQA review."
+    },
+    {
+      "id": "external-stakeholders-consultations",
+      "name": "External Stakeholders Consultations",
+      "order": 3,
+      "description": "Circulate the draft programme to PAC members and external stakeholders, benchmark with peer institutions, and prepare the final draft for PDQA recommendation."
+    },
+    {
+      "id": "internal-stakeholders-consultations",
+      "name": "Internal Stakeholders Consultations",
+      "order": 4,
+      "description": "Consult internal stakeholders on teaching, learning, assessment, delivery, cooperative education and quality assurance before institutional submission."
+    },
+    {
+      "id": "bos-apc-senate-consultations",
+      "name": "BOS, APC and Senate Consultations",
+      "order": 5,
+      "description": "Submit the final draft through BOS, APC and Senate so recommendations and approval decisions are formally recorded."
+    },
+    {
+      "id": "nqf-registration",
+      "name": "NQF Registration",
+      "order": 6,
+      "description": "Prepare and submit NQF documentation to the Namibia Qualifications Authority and record feedback, registration details and certificates."
+    }
+  ],
+  "initialTask": "stakeholders-consultation",
+  "tasks": [
+    {
+      "id": "stakeholders-consultation",
+      "stageId": "need-analysis",
+      "name": "Stakeholders Consultation",
+      "ownerRoles": [
+        "initiator"
+      ],
+      "form": [
+        {
+          "key": "startDate",
+          "label": "Consultation Start Date",
+          "type": "date",
+          "required": true
+        },
+        {
+          "key": "endDate",
+          "label": "Consultation End Date",
+          "type": "date",
+          "required": true
+        },
+        {
+          "key": "stakeholders",
+          "label": "Stakeholders",
+          "type": "repeater",
+          "required": true,
+          "minItems": 1,
+          "fields": [
+            {
+              "key": "name",
+              "label": "Stakeholder Name",
+              "type": "text",
+              "required": true
+            },
+            {
+              "key": "organisation",
+              "label": "Organisation",
+              "type": "text",
+              "required": true
+            }
+          ]
+        }
+      ],
+      "artifacts": [
+        {
+          "key": "respondent-questionnaires",
+          "label": "Questionnaires from Respondents",
+          "required": true
+        },
+        {
+          "key": "survey-final-report",
+          "label": "Survey / Final Report",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Submit Consultation",
+          "to": "pdqa-need-analysis-recommendation",
+          "notifyRoles": [
+            "pdqa"
+          ]
+        }
+      ],
+      "description": "CDC provides relevant information related to stakeholder consultation on the need of the proposed programme. Upload questionnaires, consultation evidence and the final survey report where required."
+    },
+    {
+      "id": "pdqa-need-analysis-recommendation",
+      "stageId": "need-analysis",
+      "name": "PDQA Need Analysis Recommendation",
+      "ownerRoles": [
+        "pdqa"
+      ],
+      "form": [
+        {
+          "key": "decision",
+          "label": "Decision",
+          "type": "radio",
+          "required": true,
+          "options": [
+            "recommend",
+            "approve",
+            "defer",
+            "decline"
+          ]
+        }
+      ],
+      "artifacts": [
+        {
+          "key": "need-analysis-checklist",
+          "label": "Need Analysis Checklist / Recommendation",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Recommend",
+          "when": {
+            "field": "decision",
+            "in": [
+              "recommend",
+              "approve"
+            ]
+          },
+          "to": "bos-need-analysis-consultation",
+          "notifyRoles": [
+            "bos"
+          ]
+        },
+        {
+          "event": "submit",
+          "label": "Defer",
+          "when": {
+            "field": "decision",
+            "equals": "defer"
+          },
+          "to": "stakeholders-consultation",
+          "notifyRoles": [
+            "initiator"
+          ]
+        },
+        {
+          "event": "submit",
+          "label": "Decline",
+          "when": {
+            "field": "decision",
+            "equals": "decline"
+          },
+          "to": "END",
+          "outcome": "rejected"
+        }
+      ],
+      "description": "PDQA reviews the Need Analysis report and makes a recommendation. Attach the PDQA checklist or recommendation document before submitting the decision."
+    },
+    {
+      "id": "bos-need-analysis-consultation",
+      "stageId": "need-analysis",
+      "name": "BOS Need Analysis Consultation",
+      "ownerRoles": [
+        "bos"
+      ],
+      "form": [
+        {
+          "key": "date",
+          "label": "BOS Date",
+          "type": "date",
+          "required": true
+        },
+        {
+          "key": "decision",
+          "label": "BOS Decision",
+          "type": "radio",
+          "required": true,
+          "options": [
+            "recommend",
+            "resubmit",
+            "decline"
+          ]
+        }
+      ],
+      "artifacts": [
+        {
+          "key": "bos-recommendation",
+          "label": "BOS Recommendation",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Recommend to APC",
+          "when": {
+            "field": "decision",
+            "equals": "recommend"
+          },
+          "to": "apc-need-analysis-recommendation",
+          "notifyRoles": [
+            "apc"
+          ]
+        },
+        {
+          "event": "submit",
+          "label": "Resubmit to BOS",
+          "when": {
+            "field": "decision",
+            "equals": "resubmit"
+          },
+          "to": "bos-need-analysis-consultation",
+          "notifyRoles": [
+            "bos",
+            "initiator"
+          ]
+        },
+        {
+          "event": "submit",
+          "label": "Decline",
+          "when": {
+            "field": "decision",
+            "equals": "decline"
+          },
+          "to": "END",
+          "outcome": "rejected"
+        }
+      ],
+      "description": "BOS reviews the Need Analysis report and provides a recommendation. Attach BOS minutes or recommendation evidence before submitting the decision."
+    },
+    {
+      "id": "apc-need-analysis-recommendation",
+      "stageId": "need-analysis",
+      "name": "APC Need Analysis Recommendation",
+      "ownerRoles": [
+        "apc"
+      ],
+      "form": [
+        {
+          "key": "date",
+          "label": "Consultation Date",
+          "type": "date",
+          "required": true
+        },
+        {
+          "key": "decision",
+          "label": "APC Decision",
+          "type": "radio",
+          "required": true,
+          "options": [
+            "recommend",
+            "defer",
+            "decline"
+          ]
+        }
+      ],
+      "artifacts": [
+        {
+          "key": "apc-recommendation",
+          "label": "APC Recommendation",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Recommend to Senate",
+          "when": {
+            "field": "decision",
+            "equals": "recommend"
+          },
+          "to": "senate-need-analysis-approval",
+          "notifyRoles": [
+            "senate"
+          ]
+        },
+        {
+          "event": "submit",
+          "label": "Defer to BOS",
+          "when": {
+            "field": "decision",
+            "equals": "defer"
+          },
+          "to": "bos-need-analysis-consultation",
+          "notifyRoles": [
+            "bos"
+          ]
+        },
+        {
+          "event": "submit",
+          "label": "Decline",
+          "when": {
+            "field": "decision",
+            "equals": "decline"
+          },
+          "to": "END",
+          "outcome": "rejected"
+        }
+      ],
+      "description": "The department submits the programme document to APC for review and APC makes recommendations. Upload the APC recommendation document and consultation date."
+    },
+    {
+      "id": "senate-need-analysis-approval",
+      "stageId": "need-analysis",
+      "name": "Senate Need Analysis Approval",
+      "ownerRoles": [
+        "senate"
+      ],
+      "form": [
+        {
+          "key": "date",
+          "label": "Consultation Date",
+          "type": "date",
+          "required": true
+        },
+        {
+          "key": "decision",
+          "label": "Senate Decision",
+          "type": "radio",
+          "required": true,
+          "options": [
+            "approve",
+            "defer",
+            "decline"
+          ]
+        }
+      ],
+      "artifacts": [
+        {
+          "key": "senate-recommendation",
+          "label": "Senate Recommendation",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Approve Need Analysis",
+          "when": {
+            "field": "decision",
+            "equals": "approve"
+          },
+          "to": "appoint-cdc-members",
+          "notifyRoles": [
+            "pdqa",
+            "initiator"
+          ]
+        },
+        {
+          "event": "submit",
+          "label": "Defer to APC",
+          "when": {
+            "field": "decision",
+            "equals": "defer"
+          },
+          "to": "apc-need-analysis-recommendation",
+          "notifyRoles": [
+            "apc"
+          ]
+        },
+        {
+          "event": "submit",
+          "label": "Decline",
+          "when": {
+            "field": "decision",
+            "equals": "decline"
+          },
+          "to": "END",
+          "outcome": "rejected"
+        }
+      ],
+      "description": "The department submits the programme document to Senate and Senate makes a decision. Upload the Senate recommendation or extract before completing the step."
+    },
+    {
+      "id": "appoint-cdc-members",
+      "stageId": "programme-development",
+      "name": "Appoint Curriculum Development Committee",
+      "ownerRoles": [
+        "initiator",
+        "pdqa"
+      ],
+      "form": [
+        {
+          "key": "members",
+          "label": "Curriculum Development Coordinators",
+          "type": "repeater",
+          "required": true,
+          "minItems": 1,
+          "fields": [
+            {
+              "key": "firstName",
+              "label": "First Name",
+              "type": "text",
+              "required": true
+            },
+            {
+              "key": "lastName",
+              "label": "Last Name",
+              "type": "text",
+              "required": true
+            },
+            {
+              "key": "emailAddress",
+              "label": "Email Address",
+              "type": "email",
+              "required": true
+            },
+            {
+              "key": "workNumber",
+              "label": "Work Telephone Number",
+              "type": "tel",
+              "required": true
+            },
+            {
+              "key": "cellphone",
+              "label": "Cell Number",
+              "type": "tel",
+              "required": false
+            },
+            {
+              "key": "qualification",
+              "label": "Qualification",
+              "type": "text",
+              "required": true
+            },
+            {
+              "key": "occupation",
+              "label": "Occupation",
+              "type": "text",
+              "required": true
+            },
+            {
+              "key": "organization",
+              "label": "Organisation",
+              "type": "text",
+              "required": true
+            }
+          ]
+        }
+      ],
+      "artifacts": [],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Appoint CDC",
+          "to": "appoint-pac-members",
+          "notifyRoles": [
+            "pdqa"
+          ]
+        }
+      ],
+      "description": "The department identifies and appoints the Curriculum Development Coordinator who facilitates PAC appointments in consultation with PDQA. Capture CDC member details and supporting appointment evidence."
+    },
+    {
+      "id": "appoint-pac-members",
+      "stageId": "programme-development",
+      "name": "Appoint Programme Advisory Committee",
+      "ownerRoles": [
+        "initiator",
+        "pdqa"
+      ],
+      "form": [
+        {
+          "key": "members",
+          "label": "Programme Advisory Committee Members",
+          "type": "repeater",
+          "required": true,
+          "minItems": 1,
+          "fields": [
+            {
+              "key": "firstName",
+              "label": "First Name",
+              "type": "text",
+              "required": true
+            },
+            {
+              "key": "lastName",
+              "label": "Last Name",
+              "type": "text",
+              "required": true
+            },
+            {
+              "key": "emailAddress",
+              "label": "Email Address",
+              "type": "email",
+              "required": true
+            },
+            {
+              "key": "workNumber",
+              "label": "Work Telephone Number",
+              "type": "tel",
+              "required": true
+            },
+            {
+              "key": "cellphone",
+              "label": "Cell Number",
+              "type": "tel",
+              "required": false
+            },
+            {
+              "key": "qualification",
+              "label": "Qualification",
+              "type": "text",
+              "required": true
+            },
+            {
+              "key": "occupation",
+              "label": "Occupation",
+              "type": "text",
+              "required": true
+            },
+            {
+              "key": "organization",
+              "label": "Organisation",
+              "type": "text",
+              "required": true
+            }
+          ]
+        }
+      ],
+      "artifacts": [],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Appoint PAC",
+          "to": "curriculum-drafting",
+          "notifyRoles": [
+            "cdc"
+          ]
+        }
+      ],
+      "description": "Capture Programme Advisory Committee member details, including organisation, names, email, work number, cell number, qualification and occupation where available."
+    },
+    {
+      "id": "curriculum-drafting",
+      "stageId": "programme-development",
+      "name": "Curriculum Drafting",
+      "ownerRoles": [
+        "cdc"
+      ],
+      "form": [],
+      "artifacts": [
+        {
+          "key": "draft-curriculum",
+          "label": "Draft Curriculum",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Submit Draft to PDQA",
+          "to": "pdqa-draft-curriculum-recommendation",
+          "notifyRoles": [
+            "pdqa"
+          ]
+        }
+      ],
+      "description": "CDC develops the draft programme and submits it to PDQA for review. Upload the curriculum draft document before submitting."
+    },
+    {
+      "id": "pdqa-draft-curriculum-recommendation",
+      "stageId": "programme-development",
+      "name": "Draft Curriculum and PDQA Recommendation",
+      "ownerRoles": [
+        "pdqa"
+      ],
+      "form": [
+        {
+          "key": "decision",
+          "label": "Decision",
+          "type": "radio",
+          "required": true,
+          "options": [
+            "approve",
+            "decline"
+          ]
+        }
+      ],
+      "artifacts": [
+        {
+          "key": "pdqa-curriculum-checklist",
+          "label": "PDQA Curriculum Checklist / Recommendation",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Approve Draft",
+          "when": {
+            "field": "decision",
+            "equals": "approve"
+          },
+          "to": "circulate-draft-programme",
+          "notifyRoles": [
+            "pac",
+            "initiator"
+          ]
+        },
+        {
+          "event": "submit",
+          "label": "Return for Revision",
+          "when": {
+            "field": "decision",
+            "equals": "decline"
+          },
+          "to": "curriculum-drafting",
+          "notifyRoles": [
+            "cdc"
+          ]
+        }
+      ],
+      "description": "PDQA reviews and provides recommendation on the draft programme. Upload the curriculum draft and PDQA recommendation document."
+    },
+    {
+      "id": "circulate-draft-programme",
+      "stageId": "external-stakeholders-consultations",
+      "name": "Circulation of Draft Programme",
+      "ownerRoles": [
+        "initiator",
+        "pdqa"
+      ],
+      "form": [
+        {
+          "key": "consultationDate",
+          "label": "Date",
+          "type": "date",
+          "required": true
+        }
+      ],
+      "artifacts": [
+        {
+          "key": "programme-draft",
+          "label": "Programme Draft",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Circulate Draft",
+          "to": "pac-consultation-and-benchmarking",
+          "notifyRoles": [
+            "pac"
+          ]
+        }
+      ],
+      "description": "CDC uploads the draft programme document for circulation to PAC members identified in the programme development stage."
+    },
+    {
+      "id": "pac-consultation-and-benchmarking",
+      "stageId": "external-stakeholders-consultations",
+      "name": "PAC Consultation and Benchmarking",
+      "ownerRoles": [
+        "pac"
+      ],
+      "form": [
+        {
+          "key": "consultationDate",
+          "label": "Date",
+          "type": "date",
+          "required": true
+        }
+      ],
+      "artifacts": [
+        {
+          "key": "pac-consultation-pack",
+          "label": "Final Draft / Minutes / Comments / Endorsement Letters",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Submit PAC Consultation",
+          "to": "external-final-draft-pdqa-recommendation",
+          "notifyRoles": [
+            "pdqa"
+          ]
+        }
+      ],
+      "description": "CDC convenes PAC consultation and benchmarks with peer universities and other stakeholders to solicit inputs on the draft programme. Upload benchmarking, PAC feedback, minutes or endorsement evidence."
+    },
+    {
+      "id": "external-final-draft-pdqa-recommendation",
+      "stageId": "external-stakeholders-consultations",
+      "name": "Final Draft and PDQA Recommendation",
+      "ownerRoles": [
+        "pdqa"
+      ],
+      "form": [
+        {
+          "key": "consultationDate",
+          "label": "Date",
+          "type": "date",
+          "required": true
+        },
+        {
+          "key": "decision",
+          "label": "Decision",
+          "type": "radio",
+          "required": true,
+          "options": [
+            "approve",
+            "decline"
+          ]
+        }
+      ],
+      "artifacts": [
+        {
+          "key": "final-draft-pdqa-inputs",
+          "label": "Final Draft and PDQA Inputs",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Approve External Consultation",
+          "when": {
+            "field": "decision",
+            "equals": "approve"
+          },
+          "to": "start-internal-consultations",
+          "notifyRoles": [
+            "adstlt",
+            "ceu",
+            "pdqa"
+          ]
+        },
+        {
+          "event": "submit",
+          "label": "Return for Revision",
+          "when": {
+            "field": "decision",
+            "equals": "decline"
+          },
+          "to": "curriculum-drafting",
+          "notifyRoles": [
+            "cdc"
+          ]
+        }
+      ],
+      "description": "CDC circulates the final programme draft document to PDQA for recommendation to BOS. Upload the final draft and PDQA inputs."
+    },
+    {
+      "id": "start-internal-consultations",
+      "stageId": "internal-stakeholders-consultations",
+      "name": "Start Internal Consultations",
+      "ownerRoles": [
+        "pdqa"
+      ],
+      "form": [
+        {
+          "key": "date",
+          "label": "Date",
+          "type": "date",
+          "required": true
+        },
+        {
+          "key": "includesWilComponent",
+          "label": "Includes WIL Component",
+          "type": "checkbox",
+          "required": false
+        },
+        {
+          "key": "recommendedTo",
+          "label": "Recommend To",
+          "type": "checkbox",
+          "required": true,
+          "options": [
+            "CEU",
+            "COLL",
+            "TLP"
+          ]
+        }
+      ],
+      "artifacts": [
+        {
+          "key": "drafted-programme",
+          "label": "Drafted Programme",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Start Reviews",
+          "to": "adstlt-review",
+          "notifyRoles": [
+            "adstlt"
+          ]
+        }
+      ],
+      "description": "CDC identifies relevant internal stakeholders and circulates the programme document for inputs on teaching, learning, assessment, delivery, cooperative education and quality assurance."
+    },
+    {
+      "id": "adstlt-review",
+      "stageId": "internal-stakeholders-consultations",
+      "name": "ADSTLT / TLU Review",
+      "ownerRoles": [
+        "adstlt"
+      ],
+      "form": [
+        {
+          "key": "decision",
+          "label": "Decision",
+          "type": "radio",
+          "required": true,
+          "options": [
+            "endorse",
+            "defer"
+          ]
+        }
+      ],
+      "artifacts": [
+        {
+          "key": "adstlt-support-letter",
+          "label": "ADSTLT Support Letter / Recommendation",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Endorse",
+          "when": {
+            "field": "decision",
+            "equals": "endorse"
+          },
+          "to": "ceu-review",
+          "notifyRoles": [
+            "ceu"
+          ]
+        },
+        {
+          "event": "submit",
+          "label": "Defer",
+          "when": {
+            "field": "decision",
+            "equals": "defer"
+          },
+          "to": "curriculum-drafting",
+          "notifyRoles": [
+            "cdc",
+            "pdqa"
+          ]
+        }
+      ],
+      "description": "ADS-TLT advises the department on appropriate teaching, learning and assessment strategies and provides a recommendation. Upload the support letter or review evidence."
+    },
+    {
+      "id": "ceu-review",
+      "stageId": "internal-stakeholders-consultations",
+      "name": "CEU Review",
+      "ownerRoles": [
+        "ceu"
+      ],
+      "form": [
+        {
+          "key": "decision",
+          "label": "Decision",
+          "type": "radio",
+          "required": true,
+          "options": [
+            "endorse",
+            "defer"
+          ]
+        }
+      ],
+      "artifacts": [
+        {
+          "key": "ceu-support-letter",
+          "label": "CEU Support Letter / Recommendation",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Endorse",
+          "when": {
+            "field": "decision",
+            "equals": "endorse"
+          },
+          "to": "pdqa-internal-review",
+          "notifyRoles": [
+            "pdqa"
+          ]
+        },
+        {
+          "event": "submit",
+          "label": "Defer",
+          "when": {
+            "field": "decision",
+            "equals": "defer"
+          },
+          "to": "curriculum-drafting",
+          "notifyRoles": [
+            "cdc",
+            "pdqa"
+          ]
+        }
+      ],
+      "description": "CEU ensures integration of the Work Integrated Learning component in the undergraduate programme and provides a recommendation. Upload CEU support evidence."
+    },
+    {
+      "id": "pdqa-internal-review",
+      "stageId": "internal-stakeholders-consultations",
+      "name": "PDQA Internal Review",
+      "ownerRoles": [
+        "pdqa"
+      ],
+      "form": [
+        {
+          "key": "decision",
+          "label": "Decision",
+          "type": "radio",
+          "required": true,
+          "options": [
+            "endorse",
+            "defer"
+          ]
+        }
+      ],
+      "artifacts": [
+        {
+          "key": "pdqa-internal-recommendation",
+          "label": "PDQA Support Letter / Recommendation",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Endorse",
+          "when": {
+            "field": "decision",
+            "equals": "endorse"
+          },
+          "to": "final-draft-to-bos-submission",
+          "notifyRoles": [
+            "bos"
+          ]
+        },
+        {
+          "event": "submit",
+          "label": "Defer",
+          "when": {
+            "field": "decision",
+            "equals": "defer"
+          },
+          "to": "curriculum-drafting",
+          "notifyRoles": [
+            "cdc"
+          ]
+        }
+      ],
+      "description": "PDQA reviews and verifies programme readiness for submission to BOS, makes a recommendation and provides a checklist."
+    },
+    {
+      "id": "final-draft-to-bos-submission",
+      "stageId": "bos-apc-senate-consultations",
+      "name": "Final Draft to BOS Submission",
+      "ownerRoles": [
+        "pdqa",
+        "initiator"
+      ],
+      "form": [
+        {
+          "key": "date",
+          "label": "Submission Date",
+          "type": "date",
+          "required": true
+        }
+      ],
+      "artifacts": [
+        {
+          "key": "support-letters",
+          "label": "Support Letters",
+          "required": true
+        },
+        {
+          "key": "pac-minutes",
+          "label": "PAC Minutes",
+          "required": true
+        },
+        {
+          "key": "benchmarking",
+          "label": "Benchmarking",
+          "required": true
+        },
+        {
+          "key": "draft-document",
+          "label": "Draft Document",
+          "required": true
+        },
+        {
+          "key": "checklist",
+          "label": "Checklist",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Submit to Faculty BOS",
+          "to": "faculty-bos-consultation",
+          "notifyRoles": [
+            "bos"
+          ]
+        }
+      ],
+      "description": "On recommendation made by ADS, the department circulates the final draft programme for submission to BOS. Upload the final programme documents."
+    },
+    {
+      "id": "faculty-bos-consultation",
+      "stageId": "bos-apc-senate-consultations",
+      "name": "Faculty BOS Consultation",
+      "ownerRoles": [
+        "bos"
+      ],
+      "form": [
+        {
+          "key": "date",
+          "label": "BOS Date",
+          "type": "date",
+          "required": true
+        },
+        {
+          "key": "decision",
+          "label": "Decision",
+          "type": "radio",
+          "required": true,
+          "options": [
+            "recommend-to-apc",
+            "defer"
+          ]
+        },
+        {
+          "key": "deferTo",
+          "label": "Defer To",
+          "type": "select",
+          "required": false,
+          "options": [
+            "BOSEC",
+            "BOS",
+            "Other Faculty BOS"
+          ]
+        }
+      ],
+      "artifacts": [
+        {
+          "key": "faculty-bos-programme-draft",
+          "label": "Faculty BOS Programme Draft / Recommendation",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Recommend to APC",
+          "when": {
+            "field": "decision",
+            "equals": "recommend-to-apc"
+          },
+          "to": "final-apc-recommendation",
+          "notifyRoles": [
+            "apc"
+          ]
+        },
+        {
+          "event": "submit",
+          "label": "Defer",
+          "when": {
+            "field": "decision",
+            "equals": "defer"
+          },
+          "to": "other-faculty-bos-consultation",
+          "notifyRoles": [
+            "bos",
+            "initiator"
+          ]
+        }
+      ],
+      "description": "BOS reviews the draft programme and makes recommendations. Upload the BOS recommendation document and meeting evidence."
+    },
+    {
+      "id": "other-faculty-bos-consultation",
+      "stageId": "bos-apc-senate-consultations",
+      "name": "Other Faculty BOS Consultation",
+      "ownerRoles": [
+        "bos"
+      ],
+      "form": [
+        {
+          "key": "facultyName",
+          "label": "Other Faculty Name",
+          "type": "text",
+          "required": true
+        },
+        {
+          "key": "date",
+          "label": "BOS Date",
+          "type": "date",
+          "required": true
+        },
+        {
+          "key": "recommendedTo",
+          "label": "Recommended To",
+          "type": "radio",
+          "required": true,
+          "options": [
+            "apc",
+            "bosec"
+          ]
+        }
+      ],
+      "artifacts": [
+        {
+          "key": "other-faculty-recommendation",
+          "label": "Other Faculty BOS Recommendation",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Recommend to APC",
+          "when": {
+            "field": "recommendedTo",
+            "equals": "apc"
+          },
+          "to": "final-apc-recommendation",
+          "notifyRoles": [
+            "apc"
+          ]
+        },
+        {
+          "event": "submit",
+          "label": "Return to BOSEC",
+          "when": {
+            "field": "recommendedTo",
+            "equals": "bosec"
+          },
+          "to": "final-draft-to-bos-submission",
+          "notifyRoles": [
+            "initiator",
+            "pdqa"
+          ]
+        }
+      ],
+      "description": "This step applies to multidisciplinary or interdisciplinary programmes. CDC circulates the draft programme to relevant faculties for recommendations."
+    },
+    {
+      "id": "final-apc-recommendation",
+      "stageId": "bos-apc-senate-consultations",
+      "name": "APC Recommendation",
+      "ownerRoles": [
+        "apc"
+      ],
+      "form": [
+        {
+          "key": "consultationDate",
+          "label": "Consultation Date",
+          "type": "date",
+          "required": true
+        },
+        {
+          "key": "decision",
+          "label": "APC Decision",
+          "type": "radio",
+          "required": true,
+          "options": [
+            "recommend",
+            "defer"
+          ]
+        }
+      ],
+      "artifacts": [
+        {
+          "key": "final-apc-recommendation",
+          "label": "APC Recommendation",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Recommend to Senate",
+          "when": {
+            "field": "decision",
+            "equals": "recommend"
+          },
+          "to": "final-senate-recommendation",
+          "notifyRoles": [
+            "senate"
+          ]
+        },
+        {
+          "event": "submit",
+          "label": "Defer to BOS",
+          "when": {
+            "field": "decision",
+            "equals": "defer"
+          },
+          "to": "faculty-bos-consultation",
+          "notifyRoles": [
+            "bos"
+          ]
+        }
+      ],
+      "description": "APC reviews the draft programme and provides recommendations. Upload the APC recommendation document."
+    },
+    {
+      "id": "final-senate-recommendation",
+      "stageId": "bos-apc-senate-consultations",
+      "name": "Final Senate Recommendation",
+      "ownerRoles": [
+        "senate"
+      ],
+      "form": [
+        {
+          "key": "date",
+          "label": "Senate Date",
+          "type": "date",
+          "required": true
+        }
+      ],
+      "artifacts": [
+        {
+          "key": "senate-programme-document",
+          "label": "Programme Document",
+          "required": true
+        },
+        {
+          "key": "senate-submission-letter",
+          "label": "Submission Letter to Senate",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Approve Programme",
+          "to": "nqf-documentation",
+          "notifyRoles": [
+            "pdqa",
+            "nqa"
+          ]
+        }
+      ],
+      "description": "Senate reviews the draft programme and provides a recommendation on approval. Upload the final Senate recommendation documents."
+    },
+    {
+      "id": "nqf-documentation",
+      "stageId": "nqf-registration",
+      "name": "NQF Documentation",
+      "ownerRoles": [
+        "pdqa",
+        "nqa"
+      ],
+      "form": [],
+      "artifacts": [
+        {
+          "key": "final-senate-approved-document",
+          "label": "Final Senate Approved Document",
+          "required": true
+        },
+        {
+          "key": "nqf-qualification-document",
+          "label": "NQF Qualification Document",
+          "required": true
+        },
+        {
+          "key": "review-report",
+          "label": "Review Report",
+          "required": true
+        },
+        {
+          "key": "rationale-statement",
+          "label": "Rationale Statement",
+          "required": true
+        },
+        {
+          "key": "letters-of-support",
+          "label": "Letters of Support",
+          "required": true
+        },
+        {
+          "key": "nqf-benchmarking",
+          "label": "Benchmarking",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Prepare NQF Submission",
+          "to": "pdqa-nqf-recommendation",
+          "notifyRoles": [
+            "pdqa"
+          ]
+        }
+      ],
+      "description": "CDC prepares the NQF qualification documentation for submission to ADS within 14 working days after Senate approval."
+    },
+    {
+      "id": "pdqa-nqf-recommendation",
+      "stageId": "nqf-registration",
+      "name": "PDQA NQF Recommendation",
+      "ownerRoles": [
+        "pdqa"
+      ],
+      "form": [
+        {
+          "key": "submissionType",
+          "label": "Submission Type",
+          "type": "radio",
+          "required": true,
+          "options": [
+            "initial-submission",
+            "resubmission"
+          ]
+        },
+        {
+          "key": "decision",
+          "label": "Decision",
+          "type": "radio",
+          "required": true,
+          "options": [
+            "approve",
+            "defer"
+          ]
+        }
+      ],
+      "artifacts": [
+        {
+          "key": "nqf-submission-documentation",
+          "label": "NQF Submission Documentation",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Approve Submission",
+          "when": {
+            "field": "decision",
+            "equals": "approve"
+          },
+          "to": "nqf-submission-and-feedback",
+          "notifyRoles": [
+            "nqa"
+          ]
+        },
+        {
+          "event": "submit",
+          "label": "Defer",
+          "when": {
+            "field": "decision",
+            "equals": "defer"
+          },
+          "to": "nqf-documentation",
+          "notifyRoles": [
+            "pdqa"
+          ]
+        }
+      ],
+      "description": "ADS or PDQA reviews the NQF submission from the department and prepares NQF application documentation for submission."
+    },
+    {
+      "id": "nqf-submission-and-feedback",
+      "stageId": "nqf-registration",
+      "name": "NQF Submission and Feedback",
+      "ownerRoles": [
+        "nqa"
+      ],
+      "form": [
+        {
+          "key": "submissionType",
+          "label": "Submission Type",
+          "type": "radio",
+          "required": true,
+          "options": [
+            "initial-submission",
+            "resubmission"
+          ]
+        }
+      ],
+      "artifacts": [
+        {
+          "key": "qualification-document",
+          "label": "Qualification Document",
+          "required": true
+        },
+        {
+          "key": "nqa-response",
+          "label": "NQA Response",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Record NQA Feedback",
+          "to": "nqf-registration-record",
+          "notifyRoles": [
+            "pdqa",
+            "nqa"
+          ]
+        }
+      ],
+      "description": "ADS reviews the NQF submission from the department, prepares NQF application documentation for submission, and records feedback received from NQA."
+    },
+    {
+      "id": "nqf-registration-record",
+      "stageId": "nqf-registration",
+      "name": "NQF Registration",
+      "ownerRoles": [
+        "nqa",
+        "pdqa"
+      ],
+      "form": [
+        {
+          "key": "qualificationTitle",
+          "label": "Qualification Title",
+          "type": "text",
+          "required": true
+        },
+        {
+          "key": "nqfId",
+          "label": "NQF ID",
+          "type": "text",
+          "required": true
+        },
+        {
+          "key": "registrationDate",
+          "label": "Registration Date",
+          "type": "date",
+          "required": true
+        }
+      ],
+      "artifacts": [
+        {
+          "key": "registered-qualification-document",
+          "label": "Registered Qualification Document",
+          "required": true
+        }
+      ],
+      "transitions": [
+        {
+          "event": "submit",
+          "label": "Complete Registration",
+          "to": "END",
+          "outcome": "completed"
+        }
+      ],
+      "description": "ADS submits a complete application to the Namibia Qualifications Authority for registration on the National Qualifications Framework. Record the NQF ID, title, registration date and certificate."
+    }
+  ],
+  "metadata": {
+    "generatedFrom": "client/src/app/components/forms",
+    "stagePages": [
+      "need-analysis",
+      "programme-development",
+      "external-stakeholders",
+      "internal-stakeholders",
+      "bos-apc-senate-consultations",
+      "nqf-registration"
+    ]
+  }
+}

--- a/server/src/v2/workflow/data/workflow-definition.json
+++ b/server/src/v2/workflow/data/workflow-definition.json
@@ -1,0 +1,324 @@
+{
+  "id": "curriculum-development",
+  "version": 1,
+  "name": "Curriculum Development",
+  "description": "Workflow definition for creating or revising a university programme.",
+  "roles": [
+    { "id": "hod", "name": "Head of Department" },
+    { "id": "dean", "name": "Executive Dean" },
+    { "id": "pdu", "name": "PDU / PDQA" },
+    { "id": "cdc", "name": "CDC" },
+    { "id": "pac", "name": "PAC" },
+    { "id": "tlu", "name": "TLU" },
+    { "id": "qau", "name": "QAU" },
+    { "id": "bos", "name": "Board of Studies" },
+    { "id": "senate", "name": "Senate" },
+    { "id": "nqa", "name": "NQA Liaison" }
+  ],
+  "stages": [
+    { "id": "need-analysis", "name": "Need Analysis", "order": 1 },
+    { "id": "curriculum-development", "name": "Curriculum Development", "order": 2 },
+    { "id": "consultations", "name": "Consultations", "order": 3 },
+    { "id": "pac-endorsement", "name": "PAC Endorsement", "order": 4 },
+    { "id": "tlu-review", "name": "TLU Review", "order": 5 },
+    { "id": "qau-review", "name": "QAU Review", "order": 6 },
+    { "id": "bos-approval", "name": "BOS Approval", "order": 7 },
+    { "id": "senate-approval", "name": "Senate Approval", "order": 8 },
+    { "id": "nqa-registration", "name": "NQA Registration", "order": 9 }
+  ],
+  "initialTask": "programme-resume",
+  "tasks": [
+    {
+      "id": "programme-resume",
+      "stageId": "need-analysis",
+      "name": "Programme Resume",
+      "ownerRoles": ["hod", "dean"],
+      "form": [
+        { "key": "rationale", "label": "Rationale", "type": "textarea", "required": true },
+        { "key": "targetMarket", "label": "Target Market", "type": "text", "required": true },
+        { "key": "expectedLevel", "label": "NQF Level", "type": "select", "required": true, "options": ["5", "6", "7", "8", "9"] }
+      ],
+      "artifacts": [
+        { "key": "concept-note", "label": "Concept Note", "required": true }
+      ],
+      "transitions": [
+        { "event": "submit", "label": "Submit Resume", "to": "stakeholders-consultation", "notifyRoles": ["pdu"] }
+      ]
+    },
+    {
+      "id": "stakeholders-consultation",
+      "stageId": "need-analysis",
+      "name": "Stakeholder Consultation",
+      "ownerRoles": ["pdu", "hod"],
+      "form": [
+        { "key": "organizations", "label": "Organizations Consulted", "type": "textarea", "required": true },
+        { "key": "startDate", "label": "Start Date", "type": "date", "required": true },
+        { "key": "endDate", "label": "End Date", "type": "date", "required": true }
+      ],
+      "artifacts": [
+        { "key": "questionnaire", "label": "Questionnaire", "required": true },
+        { "key": "survey-results", "label": "Survey Results", "required": true }
+      ],
+      "transitions": [
+        { "event": "submit", "label": "Record Consultation", "to": "pdqa-recommendation", "notifyRoles": ["pdu"] }
+      ]
+    },
+    {
+      "id": "pdqa-recommendation",
+      "stageId": "need-analysis",
+      "name": "PDQA Recommendation",
+      "ownerRoles": ["pdu"],
+      "form": [
+        { "key": "decision", "label": "Decision", "type": "select", "required": true, "options": ["proceed", "inconclusive"] },
+        { "key": "notes", "label": "Notes", "type": "textarea", "required": false }
+      ],
+      "artifacts": [
+        { "key": "recommendation-report", "label": "Recommendation Report", "required": true }
+      ],
+      "transitions": [
+        { "event": "submit", "label": "Proceed", "when": { "field": "decision", "equals": "proceed" }, "to": "bos-need-analysis", "notifyRoles": ["bos"] },
+        { "event": "submit", "label": "Close", "when": { "field": "decision", "equals": "inconclusive" }, "to": "END", "outcome": "stopped" }
+      ]
+    },
+    {
+      "id": "bos-need-analysis",
+      "stageId": "need-analysis",
+      "name": "BOS Need Analysis Recommendation",
+      "ownerRoles": ["bos"],
+      "form": [
+        { "key": "decision", "label": "Decision", "type": "select", "required": true, "options": ["recommended", "revision-required", "rejected"] },
+        { "key": "meetingDate", "label": "Meeting Date", "type": "date", "required": true }
+      ],
+      "artifacts": [
+        { "key": "bos-minutes", "label": "BOS Minutes", "required": true }
+      ],
+      "transitions": [
+        { "event": "submit", "label": "Recommended", "when": { "field": "decision", "equals": "recommended" }, "to": "senate-need-analysis", "notifyRoles": ["senate"] },
+        { "event": "submit", "label": "Revise", "when": { "field": "decision", "equals": "revision-required" }, "to": "stakeholders-consultation", "notifyRoles": ["hod", "pdu"] },
+        { "event": "submit", "label": "Reject", "when": { "field": "decision", "equals": "rejected" }, "to": "END", "outcome": "rejected" }
+      ]
+    },
+    {
+      "id": "senate-need-analysis",
+      "stageId": "need-analysis",
+      "name": "Senate Need Analysis Approval",
+      "ownerRoles": ["senate"],
+      "form": [
+        { "key": "decision", "label": "Decision", "type": "select", "required": true, "options": ["approved", "revision-required", "rejected"] },
+        { "key": "meetingDate", "label": "Meeting Date", "type": "date", "required": true }
+      ],
+      "artifacts": [
+        { "key": "senate-extract", "label": "Senate Extract", "required": true }
+      ],
+      "transitions": [
+        { "event": "submit", "label": "Approved", "when": { "field": "decision", "equals": "approved" }, "to": "cdc-and-pac-appointment", "notifyRoles": ["pdu", "cdc"] },
+        { "event": "submit", "label": "Revise", "when": { "field": "decision", "equals": "revision-required" }, "to": "bos-need-analysis", "notifyRoles": ["bos", "pdu"] },
+        { "event": "submit", "label": "Reject", "when": { "field": "decision", "equals": "rejected" }, "to": "END", "outcome": "rejected" }
+      ]
+    },
+    {
+      "id": "cdc-and-pac-appointment",
+      "stageId": "curriculum-development",
+      "name": "CDC and PAC Appointment",
+      "ownerRoles": ["pdu", "dean"],
+      "form": [
+        { "key": "cdcMembers", "label": "CDC Members", "type": "textarea", "required": true },
+        { "key": "pacMembers", "label": "PAC Members", "type": "textarea", "required": true },
+        { "key": "appointmentDate", "label": "Appointment Date", "type": "date", "required": true }
+      ],
+      "artifacts": [
+        { "key": "appointment-letter", "label": "Appointment Letter", "required": true }
+      ],
+      "transitions": [
+        { "event": "submit", "label": "Appoint Committees", "to": "curriculum-drafting", "notifyRoles": ["cdc"] }
+      ]
+    },
+    {
+      "id": "curriculum-drafting",
+      "stageId": "curriculum-development",
+      "name": "Curriculum Drafting",
+      "ownerRoles": ["cdc"],
+      "form": [
+        { "key": "draftVersion", "label": "Draft Version", "type": "text", "required": true },
+        { "key": "summary", "label": "Summary", "type": "textarea", "required": true }
+      ],
+      "artifacts": [
+        { "key": "curriculum-draft", "label": "Curriculum Draft", "required": true }
+      ],
+      "transitions": [
+        { "event": "submit", "label": "Submit Draft", "to": "pac-consultation", "notifyRoles": ["pac", "pdu"] }
+      ]
+    },
+    {
+      "id": "pac-consultation",
+      "stageId": "consultations",
+      "name": "PAC Consultation and Benchmarking",
+      "ownerRoles": ["pac", "pdu"],
+      "form": [
+        { "key": "benchmarkInstitutions", "label": "Benchmark Institutions", "type": "textarea", "required": true },
+        { "key": "consultationSummary", "label": "Consultation Summary", "type": "textarea", "required": true }
+      ],
+      "artifacts": [
+        { "key": "benchmark-report", "label": "Benchmark Report", "required": true },
+        { "key": "pac-feedback", "label": "PAC Feedback", "required": true }
+      ],
+      "transitions": [
+        { "event": "submit", "label": "Record Consultation", "to": "pac-endorsement", "notifyRoles": ["pac"] }
+      ]
+    },
+    {
+      "id": "pac-endorsement",
+      "stageId": "pac-endorsement",
+      "name": "PAC Endorsement",
+      "ownerRoles": ["pac"],
+      "form": [
+        { "key": "decision", "label": "Decision", "type": "select", "required": true, "options": ["endorsed", "revision-required"] },
+        { "key": "endorsementDate", "label": "Endorsement Date", "type": "date", "required": true }
+      ],
+      "artifacts": [
+        { "key": "pac-endorsement-letter", "label": "PAC Endorsement Letter", "required": true }
+      ],
+      "transitions": [
+        { "event": "submit", "label": "Endorsed", "when": { "field": "decision", "equals": "endorsed" }, "to": "tlu-review", "notifyRoles": ["tlu"] },
+        { "event": "submit", "label": "Revise", "when": { "field": "decision", "equals": "revision-required" }, "to": "curriculum-drafting", "notifyRoles": ["cdc"] }
+      ]
+    },
+    {
+      "id": "tlu-review",
+      "stageId": "tlu-review",
+      "name": "TLU Review",
+      "ownerRoles": ["tlu"],
+      "form": [
+        { "key": "decision", "label": "Decision", "type": "select", "required": true, "options": ["recommended", "revision-required"] },
+        { "key": "notes", "label": "Review Notes", "type": "textarea", "required": false }
+      ],
+      "artifacts": [
+        { "key": "tlu-review-report", "label": "TLU Review Report", "required": true }
+      ],
+      "transitions": [
+        { "event": "submit", "label": "Recommended", "when": { "field": "decision", "equals": "recommended" }, "to": "qau-review", "notifyRoles": ["qau"] },
+        { "event": "submit", "label": "Revise", "when": { "field": "decision", "equals": "revision-required" }, "to": "curriculum-drafting", "notifyRoles": ["cdc"] }
+      ]
+    },
+    {
+      "id": "qau-review",
+      "stageId": "qau-review",
+      "name": "QAU Review",
+      "ownerRoles": ["qau"],
+      "form": [
+        { "key": "decision", "label": "Decision", "type": "select", "required": true, "options": ["recommended", "revision-required"] },
+        { "key": "notes", "label": "Review Notes", "type": "textarea", "required": false }
+      ],
+      "artifacts": [
+        { "key": "qau-review-report", "label": "QAU Review Report", "required": true }
+      ],
+      "transitions": [
+        { "event": "submit", "label": "Recommended", "when": { "field": "decision", "equals": "recommended" }, "to": "bos-final-approval", "notifyRoles": ["bos"] },
+        { "event": "submit", "label": "Revise", "when": { "field": "decision", "equals": "revision-required" }, "to": "curriculum-drafting", "notifyRoles": ["cdc"] }
+      ]
+    },
+    {
+      "id": "bos-final-approval",
+      "stageId": "bos-approval",
+      "name": "BOS Final Approval",
+      "ownerRoles": ["bos"],
+      "form": [
+        { "key": "decision", "label": "Decision", "type": "select", "required": true, "options": ["approved", "revision-required", "rejected"] },
+        { "key": "meetingDate", "label": "Meeting Date", "type": "date", "required": true }
+      ],
+      "artifacts": [
+        { "key": "bos-final-minutes", "label": "BOS Final Minutes", "required": true }
+      ],
+      "transitions": [
+        { "event": "submit", "label": "Approved", "when": { "field": "decision", "equals": "approved" }, "to": "senate-final-approval", "notifyRoles": ["senate"] },
+        { "event": "submit", "label": "Revise", "when": { "field": "decision", "equals": "revision-required" }, "to": "curriculum-drafting", "notifyRoles": ["cdc"] },
+        { "event": "submit", "label": "Reject", "when": { "field": "decision", "equals": "rejected" }, "to": "END", "outcome": "rejected" }
+      ]
+    },
+    {
+      "id": "senate-final-approval",
+      "stageId": "senate-approval",
+      "name": "Senate Final Approval",
+      "ownerRoles": ["senate"],
+      "form": [
+        { "key": "decision", "label": "Decision", "type": "select", "required": true, "options": ["approved", "revision-required", "rejected"] },
+        { "key": "meetingDate", "label": "Meeting Date", "type": "date", "required": true }
+      ],
+      "artifacts": [
+        { "key": "senate-final-extract", "label": "Senate Final Extract", "required": true }
+      ],
+      "transitions": [
+        { "event": "submit", "label": "Approved", "when": { "field": "decision", "equals": "approved" }, "to": "nqf-documentation", "notifyRoles": ["pdu", "nqa"] },
+        { "event": "submit", "label": "Revise", "when": { "field": "decision", "equals": "revision-required" }, "to": "bos-final-approval", "notifyRoles": ["bos"] },
+        { "event": "submit", "label": "Reject", "when": { "field": "decision", "equals": "rejected" }, "to": "END", "outcome": "rejected" }
+      ]
+    },
+    {
+      "id": "nqf-documentation",
+      "stageId": "nqa-registration",
+      "name": "NQF Documentation Preparation",
+      "ownerRoles": ["pdu", "nqa"],
+      "form": [
+        { "key": "submissionType", "label": "Submission Type", "type": "select", "required": true, "options": ["new-programme", "revision"] },
+        { "key": "notes", "label": "Notes", "type": "textarea", "required": false }
+      ],
+      "artifacts": [
+        { "key": "qualification-document", "label": "Qualification Document", "required": true },
+        { "key": "support-pack", "label": "Support Pack", "required": true }
+      ],
+      "transitions": [
+        { "event": "submit", "label": "Prepare Submission", "to": "nqf-submission", "notifyRoles": ["nqa"] }
+      ]
+    },
+    {
+      "id": "nqf-submission",
+      "stageId": "nqa-registration",
+      "name": "NQF Submission",
+      "ownerRoles": ["nqa", "pdu"],
+      "form": [
+        { "key": "submissionDate", "label": "Submission Date", "type": "date", "required": true },
+        { "key": "referenceNumber", "label": "Reference Number", "type": "text", "required": false }
+      ],
+      "artifacts": [
+        { "key": "nqa-submission-pack", "label": "NQA Submission Pack", "required": true }
+      ],
+      "transitions": [
+        { "event": "submit", "label": "Submit to NQA", "to": "nqf-feedback", "notifyRoles": ["pdu"] }
+      ]
+    },
+    {
+      "id": "nqf-feedback",
+      "stageId": "nqa-registration",
+      "name": "NQF Feedback",
+      "ownerRoles": ["nqa", "pdu"],
+      "form": [
+        { "key": "decision", "label": "Feedback", "type": "select", "required": true, "options": ["accepted", "amendments-required"] },
+        { "key": "feedbackDate", "label": "Feedback Date", "type": "date", "required": true }
+      ],
+      "artifacts": [
+        { "key": "nqa-feedback-letter", "label": "NQA Feedback Letter", "required": true }
+      ],
+      "transitions": [
+        { "event": "submit", "label": "Accepted", "when": { "field": "decision", "equals": "accepted" }, "to": "nqf-registration", "notifyRoles": ["pdu"] },
+        { "event": "submit", "label": "Amend", "when": { "field": "decision", "equals": "amendments-required" }, "to": "nqf-documentation", "notifyRoles": ["pdu", "cdc"] }
+      ]
+    },
+    {
+      "id": "nqf-registration",
+      "stageId": "nqa-registration",
+      "name": "NQF Registration",
+      "ownerRoles": ["nqa", "pdu"],
+      "form": [
+        { "key": "nqfId", "label": "NQF ID", "type": "text", "required": true },
+        { "key": "qualificationTitle", "label": "Qualification Title", "type": "text", "required": true },
+        { "key": "registrationDate", "label": "Registration Date", "type": "date", "required": true }
+      ],
+      "artifacts": [
+        { "key": "registration-certificate", "label": "Registration Certificate", "required": true }
+      ],
+      "transitions": [
+        { "event": "submit", "label": "Register Programme", "to": "END", "outcome": "completed" }
+      ]
+    }
+  ]
+}

--- a/server/src/v2/workflow/definition.ts
+++ b/server/src/v2/workflow/definition.ts
@@ -1,4 +1,4 @@
-import curriculumDefinition from "../../../../workflow-hub/data/workflow-definition.json";
+import curriculumDefinition from "./data/workflow-definition.json";
 import type {
     CompleteTaskInput,
     WorkflowCondition,

--- a/server/tests/v2-workflow-definition.test.ts
+++ b/server/tests/v2-workflow-definition.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import lastaWorkflowDefinition from "../../workflow-hub/data/lasta-workflow-definition.json";
+import lastaWorkflowDefinition from "../src/v2/workflow/data/lasta-workflow-definition.json";
 import {
     defaultWorkflowDefinition,
     getTaskDefinition,


### PR DESCRIPTION
- Created a new workflow definition for curriculum development in JSON format, detailing roles, stages, tasks, and transitions.
- Updated the import path for the curriculum definition in the workflow definition TypeScript file to reflect the new location.
- Adjusted the import path for the lasta workflow definition in the test file to point to the correct directory structure.